### PR TITLE
Add extension songs to support "webm"

### DIFF
--- a/music.ini.template
+++ b/music.ini.template
@@ -3,7 +3,7 @@ root = library
 ; Music folder path, relative to this file
 ext_images = jpg,png
 ; Extensions to be considered for images
-ext_songs = aac,fla,flac,m4a,mp3,mp4,ogg,opus,wav
+ext_songs = aac,fla,flac,m4a,mp3,mp4,ogg,opus,wav,webm
 ; Extensions to be considered for images and songs
 maxdepth = 10
 ; Maximum recursive folder depth


### PR DESCRIPTION
This html player can support play webm (audio) extension, just add "webm" below :

music.ini
ext_songs = aac,fla,flac,m4a,mp3,mp4,ogg,opus,wav,webm