### PR TITLE
add a delete button for removing single playlist elements

### DIFF
--- a/music.css
+++ b/music.css
@@ -502,6 +502,7 @@ html:not(.dim) #player.fix {
 #clear:before { content: "\f204" }
 #crossfade:before { content: "\f1b2" }
 #enqueue:before, .add:before { content: "\f199" }
+#delete:before, .add:before { content: "\f204" }
 #export:before { content: "\f188" }
 #import:before { content: "\f17f" }
 #load:before { content: "\f180" }

--- a/music.htm
+++ b/music.htm
@@ -36,6 +36,7 @@
 		<button id="enqueue" title="Enqueue songs on click (E)" onclick="toggle(event)"><u>E</u>nqueue</button>
 		<button id="random" title="Randomize upcoming playlist songs (R)" onclick="toggle(event)"><u>R</u>andom</button>
 		<button id="crossfade" title="Crossfade between songs (O)" onclick="toggle(event)">Cr<u>o</u>ssfade</button>
+		<button id="delete" title="Delete playlist entries" onclick="toggle(event)">Delete</button>
 		<button id="playlistbtn" title="Playlist options (P)" onclick="toggle(event)"><u>P</u>laylist</button>
 		<button id="share" title="Share options (S)" onclick="toggle(event)"><u>S</u>hare</button>
 		<button id="lock" title="Lock playlist and playback controls (L)" onclick="toggleLock()"><u>L</u>ock</button>
@@ -85,9 +86,9 @@
 	<div id="playlistdiv">
 		<div>
 			<button id="clear" title="Clear the playlist (C)" onclick="clearPlaylist()"
-				ondragover="allowDrop(event)" ondrop="removeItem(event)"
+				ondragover="allowDrop(event)" ondrop="plalistItemDraggedToTrash(event)"
 				ondragenter="this.className = 'drag drop'" ondragleave="this.className = 'drag'">Clear</button>
-			<div id="playlist" onclick="playItem(event)" oncontextmenu="findItem(event)"
+			<div id="playlist" onclick="playlistClick(event)" oncontextmenu="findItem(event)"
 				ondragstart="prepDrag(event)" ondragover="allowDrop(event)" ondragend="endDrag()" ondrop="dropItem(event)"
 				ondragenter="event.target.className += ' over'" ondragleave="event.target.className = event.target.className.replace(' over', '')"
 				onmouseenter="onplaylist=true" onmouseleave="onplaylist=false"></div>

--- a/music.ini.template
+++ b/music.ini.template
@@ -30,6 +30,8 @@ def.cover = 'music.png'
 def.crossfade = false
 ; Default state for Enqueue
 def.enqueue = false
+; Default state for Delete
+def.delete = false
 ; Default state for Lock
 def.lock = false
 ; Default password for locked state

--- a/music.js
+++ b/music.js
@@ -51,6 +51,7 @@ function init() {
 		'options': get('options'),
 		'crossfade': get('crossfade'),
 		'enqueue': get('enqueue'),
+		'delete': get('delete'),
 		'random': get('random'),
 		'playlistbtn': get('playlistbtn'),
 		'playlistsdiv': get('playlistsdiv'),
@@ -126,6 +127,7 @@ function prepUI() {
 	if (cfg.enqueue) dom.enqueue.className = 'on';
 	if (cfg.random) dom.random.className = 'on';
 	if (cfg.crossfade) dom.crossfade.className = 'on';
+	if (cfg.delete) dom.delete.className = 'on';
 	if (cfg.locked) {
 		document.body.className = 'locked';
 		dom.lock.className = 'on';
@@ -488,10 +490,17 @@ function playlistItem(s) {
 	}
 	return li;
 }
-
-function playItem(e) {
-	if (!cfg.locked && e.target.tagName.toLowerCase() == 'li')
-		play(getIndex(e.target));
+function playlistClick(e) {
+	if (!cfg.locked && e.target.tagName.toLowerCase() == 'li'){
+		const index = getIndex(e.target); 
+		if(cfg.delete){
+			removePlaylistItem(index);
+		}
+		else{
+			play(index);
+		}
+	}
+		
 }
 
 function findItem(e) {
@@ -561,11 +570,7 @@ function moveItem(drag, to, indexfrom, indexto) {
 			cfg.index++;
 	}
 }
-
-function removeItem(e) {
-	e.preventDefault();
-	e.stopPropagation();
-	var index = getIndex(drag);
+function removePlaylistItem(index){
 	var playing = index == cfg.index;
 	cfg.playlist.splice(index, 1);
 	dom.playlist.removeChild(dom.playlist.childNodes[index]);
@@ -574,6 +579,12 @@ function removeItem(e) {
 		cfg.index--;
 	if (cfg.index != -1 && !playing)
 		dom.playlist.childNodes[cfg.index].className = 'playing';
+}
+
+function plalistItemDraggedToTrash(e) {
+	e.preventDefault();
+	e.stopPropagation();
+	removePlaylistItem(getIndex(drag));
 	endDrag();
 }
 


### PR DESCRIPTION
The current UI for deleting an element from playlist is to drag a playlist element to trash icon.
This is really cool, but doesn't quite work on mobile

Therefore I thought that it might be nice to have a button for that.
It works like "enqueue" in that it is a togglable mode that when enabled
deletes clicked playlist items instead of playing them.
It reuses the existing removeItem code from the dragging feature that i factored out into deletePlaylistItem.

This is debatable since it gives a second way to do something,
but since it was no work to implement I didn't ask first and just did a prototype.
If you don't think this is a good fit for the software feel free to just close this :smile:.