### PR TITLE
add simple gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/music.ini
+/library


### PR DESCRIPTION
This is a nobrainer really.
It just adds music.ini(not the template but the 'release' version)
and library(the default music library location) to a .gitignore file
so these don't get accidentally added to the repository.
This is quite useful for development since you can just have these lying around for testing purposes
(library is a symlink to my music folder for me)
and don't have to worry on git add .
